### PR TITLE
Remove char8_t define for EA_PLATFORM_APPLE

### DIFF
--- a/include/Common/EABase/eabase.h
+++ b/include/Common/EABase/eabase.h
@@ -727,11 +727,7 @@
 
 #ifndef CHAR8_T_DEFINED // If the user hasn't already defined these...
 	#define CHAR8_T_DEFINED
-	#if defined(EA_PLATFORM_APPLE)
-		#define char8_t char    // The Apple debugger is too stupid to realize char8_t is typedef'd to char, so we #define it.
-	#else
 		typedef char char8_t;
-	#endif
 	
 	#if EA_CHAR16_NATIVE
 		// In C++, char16_t and char32_t are already defined by the compiler.


### PR DESCRIPTION
Using `typedef char char8_t;` seems to work plenty fine for me, and I'm getting conflicts with libfmt because both libraries are trying to declare char8_t types. In fmt's case, `enum char8_t : unsigned char {};` is used after checking for the `__cpp_char8_t` macro. Weirdly having the conflicting types (EA's char typedef and fmt's enum) seems to work...