### PR TITLE
Add RISC-V Linux platform

### DIFF
--- a/include/Common/EABase/config/eaplatform.h
+++ b/include/Common/EABase/config/eaplatform.h
@@ -410,6 +410,10 @@
 		#define EA_PROCESSOR_X86_64 1
 		#define EA_SYSTEM_LITTLE_ENDIAN 1
 		#define EA_PLATFORM_DESCRIPTION "Linux on x64"
+	#elif defined(__riscv)
+		#define EA_PROCESSOR_RISCV 1
+		#define EA_SYSTEM_LITTLE_ENDIAN 1
+		#define EA_PLATFORM_DESCRIPTION "Linux on RISC-V"
 	#elif defined(__powerpc64__)
 		#define EA_PROCESSOR_POWERPC 1
 		#define EA_PROCESSOR_POWERPC_64 1


### PR DESCRIPTION
I am using EASTL in an embedded context and I found that it did not build on RISC-V.

```
$ riscv32-unknown-elf-gcc -dM -E -march=I -mhard-float - < /dev/null | grep -i RISCV
#define __riscv 1
```

There isn't much difference between 32- and 64-bit RISC-V so I believe this will cover both.
