### PR TITLE
Add lost install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,3 +30,8 @@ add_library(EABase INTERFACE)
 # Include dirs
 #-------------------------------------------------------------------------------------------
 target_include_directories(EABase INTERFACE include/Common)
+
+#-------------------------------------------------------------------------------------------
+# Installation
+#-------------------------------------------------------------------------------------------
+install(DIRECTORY include/Common/EABase DESTINATION include)


### PR DESCRIPTION
Not having an install target makes it difficult to use EASTL in an automatic build setup. This single line of code was removed from EASTL in 376bcdc93502208b3e61b88c911fad0f9c9e3f60. This is not by any means new code. Since this, then, clearly is the work of others (and not my own) I cannot in good confidence sign the EA CLA.
